### PR TITLE
[Tempolaly fix] fixed a bug of exporting PublicKey

### DIFF
--- a/src/point.rs
+++ b/src/point.rs
@@ -60,7 +60,7 @@ lazy_static! {
     );
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, Hash)]
 pub struct Field(BigInt);
 
 impl Field {
@@ -248,7 +248,7 @@ impl Div<&'_ Field> for &'_ Field {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, Hash)]
 pub struct Point {
     x: Field,
     y: Field,

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -33,7 +33,7 @@ pub(crate) type SeedRaw = [u8; KEY_LENGTH];
 /// This represent a private key. **Must be kept secret.**
 ///
 /// Could be used to generate a new one or restore an older already saved.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct PrivateKey(PrivateKeyRaw);
 
 opaque_debug::implement!(PrivateKey);

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -27,7 +27,7 @@ use crate::{
 /// This is a public key. _Should be distributed._
 ///
 /// You can extract a `PublicKey` by calling [`Self::from()`].
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PublicKey(Point, Option<[u8; KEY_LENGTH]>);
 
 opaque_debug::implement!(PublicKey);


### PR DESCRIPTION
I found a bug of exporting PublicKey.
If I export the PublicKey by .as_byte() method, the exported key will be wrong.
example:
```Rust
code:

use std::io::Write;

use ed448_rust::PublicKey;

fn main() {
    let a = ed448_rust::PrivateKey::new(&mut rand_core::OsRng);
    let mut file = std::fs::File::create("ed448_server_secret").unwrap();
    file.write_all(a.as_bytes()).unwrap();
    drop(file);
    let mut file = std::fs::File::create("ed448_server_public").unwrap();
    file.write_all(&ed448_rust::PublicKey::from(&a).as_byte())
        .unwrap();
    drop(file);

    let sign = a.sign(b"aaa", None).unwrap();
    PublicKey::from(PublicKey::from(&a).as_byte())
        .verify(b"aaa", &sign, None)
        .unwrap();
}

output:

thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidSignature', src/main.rs:18:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This code will be work if you use this patch and replace `PublicKey::from(&a).as_byte()` on line 18 of the above code with `PublicKey::from(&a).as_bytes()` .