### PR TITLE
Fix construction of stand-alone public keys

### DIFF
--- a/tests/rfc8032.rs
+++ b/tests/rfc8032.rs
@@ -163,6 +163,9 @@ fn ed448() {
         assert_eq!(&sig_[..], &sig[..]);
 
         pub_k.verify(&msg, &sig, context.as_deref()).unwrap();
+
+        let pub_k2 = PublicKey::try_from(&pub_key[..]).unwrap();
+        pub_k2.verify(&msg, &sig, context.as_deref()).unwrap();
     })
 }
 
@@ -211,5 +214,8 @@ fn ed448ph() {
         assert_eq!(&sig_[..], &sig[..]);
 
         pub_k.verify_ph(&msg, &sig, context.as_deref()).unwrap();
+
+        let pub_k2 = PublicKey::try_from(&pub_key[..]).unwrap();
+        pub_k2.verify_ph(&msg, &sig, context.as_deref()).unwrap();
     })
 }


### PR DESCRIPTION
The PublicKey "from" implementations didn't reverse the "encode"
operation from PublicKey::as_byte, and so a stand-alone PublicKey could
not be correctly constructed from bytes. (PublicKeys constructed from
PrivateKeys were fine.)

With this change the RFC8032 test-vectors in rfc8032.rs all pass even
when verifying the signatures using a PublicKey constructed from bytes.

A couple of unit-tests needed updating as not all 57-byte octet
sequences are valid Ed448 public keys (which is correct).

With this change an (unpublished) rust TLS client library can now successfully
connect to a GnuTLS server using ed448-rust signatures for certificates and ECDHE
parameters.